### PR TITLE
feat: add copyparty

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ https://github.com/9001/copyparty
 - https://copyparty.vpn.mm (with self-signed certificate)
 - http://laptop.lab.vpn.mm:3923
 
+### Metube
+
+https://github.com/alexta69/metube
+
+Configured to download into copyparty's `/metube_downloads` folder.
+
+- http://metube.vpn.mm
+- https://metube.vpn.mm (with self-signed certificate)
+- http://laptop.lab.vpn.mm:3924
+
 ## Manual Deployment
 
 Both workflows can be triggered manually via GitHub Actions UI using the "Run workflow" button.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ SSH keys have been generated and distributed to both servers. GitHub secrets are
 https://github.com/9001/copyparty
 
 - http://copyparty.vpn.mm
+- https://copyparty.vpn.mm (self-signed certificate)
 - http://laptop.lab.vpn.mm:3923
 
 ## Manual Deployment

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ SSH keys have been generated and distributed to both servers. GitHub secrets are
 https://github.com/9001/copyparty
 
 - http://copyparty.vpn.mm
-- https://copyparty.vpn.mm (self-signed certificate)
+- https://copyparty.vpn.mm (with self-signed certificate)
 - http://laptop.lab.vpn.mm:3923
 
 ## Manual Deployment

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ SSH keys have been generated and distributed to both servers. GitHub secrets are
 - http://whoami.vpn.mm
 - https://whoami.vpn.mm (with self-signed certificate)
 
+### Copyparty
+
+https://github.com/9001/copyparty
+
+- http://copyparty.vpn.mm
+- http://laptop.lab.vpn.mm:3923
+
 ## Manual Deployment
 
 Both workflows can be triggered manually via GitHub Actions UI using the "Run workflow" button.

--- a/caddy/laptop.lab.Caddyfile
+++ b/caddy/laptop.lab.Caddyfile
@@ -59,3 +59,14 @@ https://whoami.vpn.mm {
     tls internal # use self-signed certificate
     reverse_proxy localhost:16002
 }
+
+## Copyparty
+http://copyparty.vpn.mm {
+    reverse_proxy localhost:3923
+}
+
+https://copyparty.vpn.mm {
+    # use self-signed certificate
+    tls internal
+    reverse_proxy localhost:3923
+}

--- a/caddy/laptop.lab.Caddyfile
+++ b/caddy/laptop.lab.Caddyfile
@@ -61,12 +61,18 @@ https://whoami.vpn.mm {
 }
 
 ## Copyparty
+# Using tailscale auth for identity:
+# https://github.com/9001/copyparty/tree/hovudstraum?tab=readme-ov-file#generic-header-auth
+# And returning 403 if not accessed through Tailscale (somehow)
 http://copyparty.vpn.mm {
+    import authz_tailscale
+    import ts_identity_required
     reverse_proxy localhost:3923
 }
 
 https://copyparty.vpn.mm {
-    # use self-signed certificate
-    tls internal
+    import authz_tailscale
+    import ts_identity_required
+    tls internal # use self-signed certificate
     reverse_proxy localhost:3923
 }

--- a/caddy/laptop.lab.Caddyfile
+++ b/caddy/laptop.lab.Caddyfile
@@ -76,3 +76,18 @@ https://copyparty.vpn.mm {
     tls internal # use self-signed certificate
     reverse_proxy localhost:3923
 }
+
+## Metube
+# yt-dlp UI downloading into copyparty's /metube_downloads folder
+http://metube.vpn.mm {
+    import authz_tailscale
+    import ts_identity_required
+    reverse_proxy localhost:3924
+}
+
+https://metube.vpn.mm {
+    import authz_tailscale
+    import ts_identity_required
+    tls internal # use self-signed certificate
+    reverse_proxy localhost:3924
+}

--- a/headscale/extra-records.json
+++ b/headscale/extra-records.json
@@ -23,5 +23,10 @@
         "name": "mtib.dev.vpn.mm",
         "type": "A",
         "value": "100.104.3.1"
+    },
+    {
+        "name": "copyparty.vpn.mm",
+        "type": "A",
+        "value": "100.104.3.2"
     }
 ]


### PR DESCRIPTION
Running this docker-compose.yml:

```yaml
services:
  copyparty:
    image: copyparty/ac:latest
    container_name: copyparty
    ports:
      - 3923:3923
    volumes:
      - ./cfg:/cfg:z
      - copyparty-data:/w:z
    stop_grace_period: 15s  # thumbnailer is allowed to continue finishing up for 10s after the shutdown signal
    healthcheck:
      test: ["CMD-SHELL", "wget --spider -q 127.0.0.1:3923/?reset"]
      interval: 1m
      timeout: 2s
      retries: 5
      start_period: 15s
  metube:
    image: ghcr.io/alexta69/metube
    container_name: metube
    restart: unless-stopped
    ports:
      - 3924:8081
    volumes:
      - type: volume
        source: copyparty-data
        target: /downloads
        volume:
          subpath: metube_downloads
volumes:
  copyparty-data:
```

on the lab. Intentionally only accessible in VPN (as I wouldn't trust this to be super secure outside of one). RW without login, RW+delete+admin with login: mal:mal, mtib:mtib (to be changed if exposed on the web)

Already accessible at http://laptop.lab.vpn.mm:3923/ this just aims to give it a custom DNS at http://copyparty.vpn.mm and https://copyparty.vpn.mm with a self-signed certificate.

---

Edit: also added Metube at http://metube.vpn.mm and https://metube.vpn.mm, to download straight from most online video/audio platforms into /metube_downloads